### PR TITLE
Prevented password disclosure in response to the registration endpoint.

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -13,7 +13,7 @@ class RegisterSerializer(ModelSerializer):
     class Meta:
         model = CustomUser
         fields = ("username", "password", "email")
-        extra_kwargs = {"email": {"required": True}}
+        extra_kwargs = {"email": {"required": True}, "password": {"write_only": True}}
 
     def validate_password(self, value):
         # Password List Source: https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/10k-most-common.txt


### PR DESCRIPTION
The **authentication** serializer did not prevent disclosure of the restricted **password** attribute of the user model. Therefore each registered user was able to view their hashed password as a result of accessing the `/api/v1/authentication/register` endpoint. This PR fixes issue #30 .